### PR TITLE
Merge branch 'feature/home-frontend' into dev

### DIFF
--- a/src/components/advert/AdvertFilter.tsx
+++ b/src/components/advert/AdvertFilter.tsx
@@ -1,0 +1,74 @@
+import { useState, type ChangeEvent, type FormEvent } from "react";
+import type { Filter } from "../../pages/advert/types";
+
+interface FilterProps {
+  onSubmit: (filter: Filter) => void;
+}
+
+function AdvertFilter({ onSubmit }: FilterProps) {
+  const [filters, setFilters] = useState<Filter>({});
+
+  function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    onSubmit(filters);
+  }
+
+  function handleNameChange(event: ChangeEvent<HTMLInputElement>) {
+    const value = event.target.value;
+    setFilters((prev) => ({ ...prev, name: value }));
+  }
+
+  function handleTypeChange(event: ChangeEvent<HTMLSelectElement>) {
+    const value = event.target.value;
+    setFilters((prev) => ({
+      ...prev,
+      offer: value === "" ? undefined : value === "true",
+    }));
+  }
+
+  return (
+    <div className="mb-8 rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+      <form
+        onSubmit={handleSubmit}
+        className="grid grid-cols-1 gap-4 lg:grid-cols-6"
+      >
+        <div className="flex flex-col lg:col-span-2">
+          <label htmlFor="name" className="mb-2 font-medium">
+            Search
+          </label>
+          <input
+            type="search"
+            id="name"
+            name="name"
+            value={filters.name ?? ""}
+            placeholder="Search by name"
+            maxLength={80}
+            onChange={handleNameChange}
+            className="h-10.5 w-full rounded-lg border border-gray-200 px-3 py-2 placeholder:text-gray-200"
+          />
+        </div>
+        <div className="flex flex-col">
+          <label htmlFor="offer" className="mb-2 font-medium">
+            Type
+          </label>
+          <select
+            id="offer"
+            name="offer"
+            value={
+              typeof filters.offer === "boolean" ? String(filters.offer) : ""
+            }
+            className="h-10.5 rounded-lg border border-gray-200 px-3 py-2"
+            onChange={handleTypeChange}
+          >
+            <option value="">All Types</option>
+            <option value="false">Need Service</option>
+            <option value="true">Offer Service</option>
+          </select>
+        </div>
+        <button type="submit">Search</button>
+      </form>
+    </div>
+  );
+}
+
+export default AdvertFilter;

--- a/src/components/advert/Pagination.tsx
+++ b/src/components/advert/Pagination.tsx
@@ -14,19 +14,22 @@ function Pagination({ current, total, onPageChange }: PaginationProps) {
   const pages = Array.from({ length: total }, (_, i) => i + 1);
 
   return (
-    <div className="mb-6 flex justify-center gap-2">
+    <div className="mb-6 flex justify-center gap-2" aria-label="Pagination">
       <button
         onClick={() => current > 1 && onPageChange(current - 1)}
         disabled={current === 1}
         className="btn btn-secondary"
+        aria-label="Go to the previous page"
       >
-        {"<"}
+        <span aria-hidden="true">{"<"}</span>
       </button>
       {pages.map((page) => (
         <button
           key={page}
           onClick={() => onPageChange(page)}
           disabled={page === current}
+          aria-label={`Go to page ${page}`}
+          aria-current={page === current ? "page" : undefined}
           className={clsx(
             "btn",
             page === current ? "btn-primary" : "btn-secondary",
@@ -39,8 +42,9 @@ function Pagination({ current, total, onPageChange }: PaginationProps) {
         onClick={() => current < total && onPageChange(current + 1)}
         disabled={current === total}
         className="btn btn-secondary"
+        aria-label="Go to the next page"
       >
-        {">"}
+        <span aria-hidden="true">{">"}</span>
       </button>
     </div>
   );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,5 @@
 //DEPENDENCIES
-import { useEffect, useRef } from "react";
+import { useEffect, useState } from "react";
 import { Link } from "react-router";
 
 //NATIVE
@@ -10,25 +10,38 @@ import { getAdverts, getPagination, getUi } from "../store/selectors";
 import AdvertCard from "../components/advert/AdvertCard";
 import Pagination from "../components/advert/Pagination";
 import Alert from "../components/ui/Alert";
+import AdvertFilter from "../components/advert/AdvertFilter";
+import type { Filter } from "./advert/types";
 
 export default function Home() {
   const advertsLoadAction = useAdvertsLoadAction();
   const uiResetErrorAction = useUiResetError();
   const adverts = useAppSelector(getAdverts);
   const { pending, error } = useAppSelector(getUi);
-  const { page, totalPages } = useAppSelector(getPagination);
-  const didFetch = useRef(false);
+  const { totalPages } = useAppSelector(getPagination);
+  const [filter, setFilter] = useState<Filter>({});
+  const [page, setPage] = useState(1);
+
+  function handleFilterSubmit(newFilter: Filter) {
+    setFilter(newFilter);
+    setPage(1);
+  }
 
   function handlePageChange(newPage: number) {
-    advertsLoadAction({ page: newPage.toString() });
+    setPage(newPage);
   }
 
   useEffect(() => {
-    if (!didFetch.current) {
-      advertsLoadAction({ page: page.toString() });
-      didFetch.current = true;
-    }
-  }, [advertsLoadAction, page]);
+    const params: Record<string, string> = {
+      page: page.toString(),
+      ...(filter.name ? { name: filter.name } : {}),
+      ...(typeof filter.offer === "boolean"
+        ? { offer: String(filter.offer) }
+        : {}),
+    };
+
+    advertsLoadAction(params);
+  }, [page, filter]);
 
   return (
     <>
@@ -36,17 +49,22 @@ export default function Home() {
         <h1>Welcome Home</h1>
         <p>This is the home page</p>
         <div className="mx-auto max-w-7xl px-6 py-8">
+          <AdvertFilter onSubmit={handleFilterSubmit} />
           {pending ? (
             <p>Loading...</p>
           ) : adverts.length ? (
             <ul className="mb-8 grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-              {adverts.map((advert) => (
-                <li key={advert._id}>
-                  <Link to={`/adverts/${advert._id}`}>
-                    <AdvertCard advert={advert} />
-                  </Link>
-                </li>
-              ))}
+              {adverts.length ? (
+                adverts.map((advert) => (
+                  <li key={advert._id}>
+                    <Link to={`/adverts/${advert._id}`}>
+                      <AdvertCard advert={advert} />
+                    </Link>
+                  </li>
+                ))
+              ) : (
+                <p>Adverts not found</p>
+              )}
             </ul>
           ) : (
             <p>Advert empty</p>

--- a/src/pages/advert/types.ts
+++ b/src/pages/advert/types.ts
@@ -16,3 +16,11 @@ export interface AdvertResponse {
   totalAdverts: number;
   totalPages: number;
 }
+
+export interface Filter {
+  name?: string;
+  minPrice?: number;
+  maxPrice?: number;
+  offer?: boolean;
+  category?: string[];
+}


### PR DESCRIPTION
Se ha añadido el componente `AdvertFilter.tsx`, un menú para filtrar los anuncios dentro de Home (WIP, faltan filtros de categoría y precio).

Se ha añadido el type `Filter` que recoge los campos por los que un usuario debe filtrar el listado de anuncios (`owner` queda excluido ya que eso solo se debería aplicar en el profile de un usuario.

Se incluyeron etiquetas de accesibilidad en la paginación.

Se ha integrado el filtrado de anuncios en Home (WIP, faltan filtros de categoría y precio) y corregido el problema con la paginación, ahora `advertsLoadAction()` se disparará cuando se cambie de página o haya un submit en el menú de filtros. Opté por onSubmit porque onChange dispara constantemente la acción por cada cambio de los inputs de filtrado.